### PR TITLE
make seperator between key and value configurable via an env variable

### DIFF
--- a/fet.sh
+++ b/fet.sh
@@ -100,7 +100,7 @@ read -r model < /sys/devices/virtual/dmi/id/product_name
 [ $# -gt 0 ] && pkgs=$#
 
 print() {
-	[ "$2" ] && printf '\033[3%sm%6s\033[0m ~ %s\n' "${accent:-4}" "$1" "$2"
+	[ "$2" ] && printf '\033[9%sm%6s\033[0m%b%s\n' "${accent:-4}" "$1" "${separator:- ~ }" "$2"
 }
 
 


### PR DESCRIPTION
This PR adds the option to configure the seperator between keys and values using the `separator` environment variable