### PR TITLE
change where hostname is read.

### DIFF
--- a/fet.sh
+++ b/fet.sh
@@ -105,7 +105,7 @@ print() {
 
 
 echo
-read -r host < /etc/hostname
+read -r host < /proc/sys/kernel/hostname
 printf '%7s@%s\n' "$USER" "$host"
 
 print os "$ID"


### PR DESCRIPTION
Wouldn't it make more sense to read hostname from /proc/sys/kernel/hostname, since all distroes dont get their hostname from /etc/hostname