### PR TITLE
check for os-release located at /usr/lib/os-release if /etc/os-release is not found

### DIFF
--- a/fet.sh
+++ b/fet.sh
@@ -20,6 +20,12 @@ _() {  # [ a = b ] with globbing
 
 ## Distro
 o=/etc/os-release
+
+## Some distros have them located at /usr/lib/os-release; according to freedesktop.org
+if [[ ! -f "$o" ]]; then
+	o=/usr/lib/os-release
+fi
+
 [ -f $o ] && . $o   # a common file that has variables about the distro
 
 if [ -e /proc/$$/comm ]; then


### PR DESCRIPTION
Some distros have the `os-release` located at the `/usr/lib/os-release`; [stating from freedesktop.org](https://www.freedesktop.org/software/systemd/man/os-release.html).

So adding an if statement pointing `/usr/lib/os-release` if `/etc/os-release` is not found.

