### PR TITLE
Add Gentoo package

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ fetch written in POSIX shell with no external commands
 
 ### Installing
 **Arch:** [fet.sh-git](https://aur.archlinux.org/packages/fet.sh-git/) (AUR)  
+**Gentoo:** [app-misc/fetsh](https://gpo.zugaina.org/Overlays/guru/app-misc/fetsh) (GURU overlay)  
 **Other Distros:** copy `fet.sh` to somewhere in $PATH
 
 ### Customization


### PR DESCRIPTION
I added the Gentoo and NixOS packages to the README. I've already
written a report to Repology that the projects [fet.sh, fet-sh and fetsh](https://repology.org/project/fet.sh/related) should be merged.
When these are merged, they will appear on this Repology badge and you can use it in the README:
[![Packaging status](https://repology.org/badge/vertical-allrepos/fet.sh.svg)](https://repology.org/project/fet.sh/versions)