### PR TITLE
Show more information on kernel line

### DIFF
--- a/fet.sh
+++ b/fet.sh
@@ -88,7 +88,7 @@ if [ -e /proc/$$/comm ]; then
 
 	## Kernel
 	read -r _ _ version _ < /proc/version
-	kernel=${version%%-*}
+	kernel=${version%%-}
 	eq "$version" '*Microsoft*' && ID="fake $ID"
 
 	## Motherboard // laptop


### PR DESCRIPTION
Shows more detailed kernel information, eg. the patch number and whether it's an lts kernel or not on the kernel line

Before:
  `kern ~ 5.4.71`

After:
  `kern ~ 5.4.71-1-lts`