### PR TITLE
Add configuration support for the color blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Supported options are:
 - `accent` (0-7)
 - `info`
 - `separator`
+- `colorblock`
 
 For less simple configuration I recommend editing the script, I tried to keep it simple.
 

--- a/fet.sh
+++ b/fet.sh
@@ -237,7 +237,7 @@ cpu=${cpu% *-Core*}
 col() {
 	printf '  '
 	for i in 1 2 3 4 5 6; do
-		printf '\033[9%sm▅▅' "$i"
+		printf '\033[9%sm%s' "$i" "${colorblock:-▅▅}"
 	done
 	printf '\033[0m\n'
 }


### PR DESCRIPTION
I found this a useful configuration to have: it was simple, and it allows for multiple shells/users/programs to run the same fet.sh and avoid issues with Unicode block rendering.

All it does is allow for a `colorblock` variable to be set to change the characters in the color line. It does not break any existing functionality.